### PR TITLE
Feature/add generic stores

### DIFF
--- a/src/store/example-generic/index.js
+++ b/src/store/example-generic/index.js
@@ -1,0 +1,24 @@
+import { build as actionsFactory } from '../generic/actionsFactory'
+import { build as gettersFactory } from '../generic/gettersFactory'
+import { build as mutationsFactory } from '../generic/mutationsFactory'
+import { build as stateFactory } from '../generic/stateFactory'
+
+const getters = { ...gettersFactory(), ...{} }
+const state = { ...stateFactory(), ...{} }
+const mutations = {
+  ...mutationsFactory(), ...{}
+}
+const actions = {
+  ...actionsFactory('resourceNamespace', {
+    // dbTable: 'users', // DBUndex table to store data localy
+  }),
+  ...{}
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+}

--- a/src/store/generic/actionsFactory.js
+++ b/src/store/generic/actionsFactory.js
@@ -1,0 +1,209 @@
+import JSON_ from 'json_'
+import { DB } from 'src/app/database/index'
+
+const toSnakeCase = (obj) => {
+  return JSON.parse(JSON_.stringify(obj))
+}
+
+const toCamelCase = (obj) => {
+  return JSON_.parse(JSON.stringify(obj))
+}
+
+export const build = (NAMESPACE, options) => {
+  const DEFAULT = {
+    uniqueKey: 'id',
+    dbTable: NAMESPACE
+  }
+  const CONFIG = { ...DEFAULT,
+    ...options
+  }
+  const COLLECTION = DB[CONFIG['dbTable']]
+  const MUTATIONS = {
+    ADD: NAMESPACE + '/add',
+    UPDATE: NAMESPACE + '/update',
+    DELETE: NAMESPACE + '/delete'
+  }
+
+  const actions = {}
+
+  actions.store = ({
+    commit,
+    state
+  }, payload) => {
+    return new Promise((resolve, reject) => {
+      let item = { ...{
+        id: null
+      },
+      ...payload
+      }
+      if (!item.id) {
+        delete item.id
+        COLLECTION.add(toSnakeCase(item)).then((itemId) => {
+          item.id = itemId
+          commit(MUTATIONS.ADD, item, {
+            root: true
+          })
+          resolve(item)
+        }, reject)
+      } else {
+        COLLECTION.put(toSnakeCase(item)).then((itemId) => {
+          commit(MUTATIONS.UPDATE, item, {
+            root: true
+          })
+          resolve(item)
+        }, reject)
+      }
+    })
+  }
+
+  actions.all = (store) => {
+    return new Promise((resolve, reject) => {
+      COLLECTION.toArray().then((collection) => {
+        collection.map((item) => {
+          actions.get(store, item.id).then((storedItemId) => {
+            store.commit(MUTATIONS.UPDATE, toCamelCase(item), {
+              root: true
+            })
+          }, (err) => {
+            if (err) {
+              console.log('Error getting ' + NAMESPACE)
+              console.log(err)
+            }
+            store.commit(MUTATIONS.ADD, toCamelCase(item), {
+              root: true
+            })
+          })
+        })
+        resolve(collection)
+      })
+    })
+  }
+
+  actions.get = ({
+    commit,
+    state
+  }, itemId) => {
+    return new Promise((resolve, reject) => {
+      const item = state._collection[itemId]
+      if (item) {
+        return resolve(item)
+      }
+
+      COLLECTION.where({
+        id: itemId
+      }).first().then((item) => {
+        if (item) {
+          commit(MUTATIONS.ADD, toCamelCase(item), {
+            root: true
+          })
+          resolve(toCamelCase(item))
+        } else {
+          reject(item)
+        }
+      }, (err) => {
+        reject(err)
+      })
+    })
+  }
+
+  actions.delete = ({
+    commit,
+    state
+  }, itemId) => {
+    return new Promise((resolve, reject) => {
+      COLLECTION.where({
+        id: itemId
+      }).delete().then(() => {
+        commit(MUTATIONS.DELETE, itemId, {
+          root: true
+        })
+        resolve(itemId)
+      }, (err) => {
+        reject(err)
+      })
+    })
+  }
+
+  actions.getByKey = ({
+    commit,
+    state,
+    getters
+  }, {
+    key,
+    value
+  }) => {
+    return new Promise((resolve, reject) => {
+      const item = getters.all.find(item => item[key] === value)
+      if (item) {
+        return resolve(item)
+      }
+
+      COLLECTION.where(toSnakeCase({
+        [key]: value
+      })).first().then((item) => {
+        if (item) {
+          commit(MUTATIONS.ADD, toCamelCase(item), {
+            root: true
+          })
+          resolve(toCamelCase(item))
+        } else {
+          reject(item)
+        }
+      }, (err) => {
+        reject(err)
+      })
+    })
+  }
+
+  actions.getAllByKey = ({
+    commit,
+    state,
+    getters
+  }, {
+    key,
+    value
+  }) => {
+    return new Promise((resolve, reject) => {
+      const items = getters.all.filter(item => item[key] === value)
+      if (items && items.length) {
+        return resolve(items)
+      }
+      COLLECTION.where(toSnakeCase({
+        [key]: value
+      })).toArray().then((items) => {
+        if (items) {
+          resolve(items.map(item => {
+            item = getters.hydrateRelationshipAttributes(toCamelCase(item))
+            commit(MUTATIONS.ADD, item, {
+              root: true
+            })
+            debugger
+            return item
+          }))
+        } else {
+          reject(items)
+        }
+      }, (err) => {
+        reject(err)
+      })
+    })
+  }
+
+  actions.unique = (store, payload) => {
+    let self = actions
+    return new Promise((resolve, reject) => {
+      self.getByKey(store, {
+        key: CONFIG.uniqueKey,
+        value: payload
+      }).then(storedItem => {
+        reject(storedItem)
+      }, error => {
+        if (error) {
+          console.log(error)
+          resolve(true)
+        }
+      })
+    })
+  }
+  return actions
+}

--- a/src/store/generic/gettersFactory.js
+++ b/src/store/generic/gettersFactory.js
@@ -1,0 +1,58 @@
+export const build = (options) => {
+  const DEFAULTS = {
+    hydrateRelationships: false
+  }
+  const CONFIG = { ...DEFAULTS, ...options }
+  const getters = {}
+
+  getters.hydrateRelationshipAttributes = () => (item) => item
+  getters.hydrateRelationships = () => (item) => item
+
+  getters.all = (state, getters, rootState, rootGetters) => {
+    return state.collection.map((itemId) => {
+      return getters.hydrateRelationshipAttributes(state._collection[itemId])
+    }).map(item => {
+      return getters.hydrateRelationships(item)
+    })
+  }
+
+  getters.find = (state, getters, rootState, rootGetters) => (itemId) => {
+    return state._collection[itemId]
+  }
+
+  if (Array.isArray(CONFIG.hydrateRelationshipAttributes)) {
+    getters.hydrateRelationshipAttributes = (state, getters, rootState, rootGetters) => (item) => {
+      let mapped = CONFIG.hydrateRelationshipAttributes.reduce((mapped, relationship) => {
+        const FOREIGN_GETTER = rootGetters[relationship.foreignGetter]
+        const FOREIGN_KEY = relationship.foreignKey
+        const FOREIGN_NAME = relationship.foreignName
+        const FOREIGN_VALUE = relationship.foreignValue
+
+        const relatedItem = FOREIGN_GETTER(item[FOREIGN_KEY])
+        mapped[FOREIGN_NAME] = relatedItem ? relatedItem[FOREIGN_VALUE] : ''
+        return mapped
+      }, {})
+      return { ...mapped, ...item }
+    }
+  } else if (CONFIG.hydrateRelationshipAttributes) {
+    throw new Error('Invalid hydration config, must be an array')
+  }
+
+  if (Array.isArray(CONFIG.relationships)) {
+    getters.hydrateRelationships = (state, getters, rootState, rootGetters) => (item) => {
+      return CONFIG.relationships.reduce((mapped, relationship) => {
+        const FOREIGN_GETTER = rootGetters[relationship.foreignGetter]
+        const FOREIGN_KEY = relationship.foreignKey
+        const FOREIGN_NAME = relationship.name
+
+        const relatedItem = FOREIGN_GETTER(item[FOREIGN_KEY])
+        mapped[FOREIGN_NAME] = relatedItem || null
+        return mapped
+      }, item)
+    }
+  } else if (CONFIG.relationships) {
+    throw new Error('Invalid relationships config, must be an array')
+  }
+
+  return getters
+}

--- a/src/store/generic/mutationsFactory.js
+++ b/src/store/generic/mutationsFactory.js
@@ -1,0 +1,18 @@
+export const build = (NAMESPACE, options) => {
+  const mutations = {}
+  mutations.add = (state, payload) => {
+    if (state.collection.findIndex(itemId => itemId === payload.id) === -1) {
+      state._collection[payload.id] = payload
+      state.collection.push(payload.id)
+    }
+  }
+  mutations.update = (state, payload) => {
+    state._collection = { ...state._collection, [payload.id]: payload }
+  }
+  mutations.delete = (state, payload) => {
+    delete state._collection[payload]
+    let index = state.collection.indexOf(payload)
+    state.collection.splice(index, 1)
+  }
+  return mutations
+}

--- a/src/store/generic/stateFactory.js
+++ b/src/store/generic/stateFactory.js
@@ -1,0 +1,6 @@
+export const build = () => {
+  return {
+    _collection: {},
+    collection: []
+  }
+}

--- a/src/store/users/actions.js
+++ b/src/store/users/actions.js
@@ -1,26 +1,20 @@
 import User from 'services/user.service'
 
-export const getCurrentUser = async ({ commit, state, getters }, payload) => {
+export const getCurrentUser = async ({ commit, state }, payload) => {
   if (state.currentUser) return state.currentUser
-
-  return User.currentUser()
+  let user_promise = User.currentUser()
+  user_promise
     .then(user => {
-      commit('users/setCurrentUser', user, {
+      commit('users/setCurrentUser', user.attributes, {
         root: true
       })
-      return getters['currentUser']
     })
 }
 
-export const setCurrentUser = (vuex, user) => {
-  const { commit } = vuex
-  commit('users/setCurrentUser', user, {
-    root: true
-  })
-}
-
 export const destroyCurrentUser = ({ commit, state }, payload) => {
-  commit('users/setCurrentUser', null, {
+  commit('users/setCurrentUser', {
+    data: null
+  }, {
     root: true
   })
 }

--- a/src/store/users/index.js
+++ b/src/store/users/index.js
@@ -1,7 +1,24 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import { build as actionsFactory } from '../generic/actionsFactory'
+import { build as gettersFactory } from '../generic/gettersFactory'
+import { build as mutationsFactory } from '../generic/mutationsFactory'
+import { build as stateFactory } from '../generic/stateFactory'
+import * as userActions from './actions'
+import * as userGetters from './getters'
+import * as userMutations from './mutations'
+import userState from './state'
+
+const getters = { ...gettersFactory(), ...userGetters }
+const state = { ...stateFactory(), ...userState }
+const mutations = {
+  ...mutationsFactory(), ...userMutations
+}
+const actions = {
+  ...actionsFactory('users', {
+    dbTable: 'users',
+    uniqueKey: 'email'
+  }),
+  ...userActions
+}
 
 export default {
   namespaced: true,


### PR DESCRIPTION
This adds a generic store that is connected to IndexDB and has CRUD like operations enabled, currently supported actions:

- store
- all
- get
- delete
- getByKey
- getAllByKey
- unique

Generic getters allow to "hydrate" relationships from related models in the store, currently available getters:

- all
- find

The state uses an object to store indexed results by key and also an array to store the wanted order of the items.